### PR TITLE
Update update_server.py

### DIFF
--- a/update_server.py
+++ b/update_server.py
@@ -166,6 +166,15 @@ class SafelistUpdateServer(ServiceUpdater):
 
                     hash_list = []
 
+            #Put remaining items in hash_list into safelist since no length of hash_list less than HASH_LEN will ever pass the "if len(hash_list) % HASH_LEN == 0:"
+            #For computational effeciency, instead of checking this if statmeent each line, we can simply check it after reading all lines from the file in previous for loop
+            if len(hash_list) < HASH_LEN and len(hash_list) > 0:
+                try:
+                    resp = client._connection.put("api/v4/safelist/add_update_many/", json=hash_list)
+                    success += resp['success']
+                except Exception as e:
+                    self.log.error(f"Failed to insert hash into safelist: {str(e)}")
+
         os.unlink(file_path)
         self.log.info(f"Import finished. {success} hashes have been processed.")
 


### PR DESCRIPTION
Iterating through the lines we are using a mod calculation to determine if the number of items in hash_list is divisible by HASH_LEN, which by default == 1000. This approach is good for memory allocation as well as network bandwidth; however, it will neglect whatever items remain after the last time hash_list IS divisible by 1000. For example: If we have 2,500 items, the if check using mod % will succeed 2 times putting the first 2,000 items from the file into safelist. The remaining 500 items will be placed into hash_list, but never make it to a client._connection.put call to put them into safelist. This additional if statement solves and handles the remaining 500 items such that all hashes found in source text are put into safelist appropriately.