### PR TITLE
Use 7z to handle large ISOs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM cccs/assemblyline-v4-service-base:$branch
 
 ENV SERVICE_PATH safelist.Safelist
 
+USER root
+RUN apt update -y && apt install -y p7zip-full
+
 # Switch to assemblyline user
 USER assemblyline
 

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -67,3 +67,6 @@ update_config:
     # - name: NSRL_android
     #   pattern: NSRLFile.txt
     #   uri: https://s3.amazonaws.com/rds.nsrl.nist.gov/RDS/current/RDS_android.iso
+    # - name: NSRL_legacy
+    #   pattern: NSRLFile.txt
+    #   uri: https://s3.amazonaws.com/rds.nsrl.nist.gov/RDS/current/RDS_legacy.iso

--- a/update_server.py
+++ b/update_server.py
@@ -224,8 +224,6 @@ class SafelistUpdateServer(ServiceUpdater):
                 uri: str = source['uri']
                 self.log.info(f"Processing source: {source['name'].upper()}")
                 download_name = os.path.basename(uri)
-                orig_source_pattern = source['pattern']
-                source['pattern'] = f'.*{download_name}'
 
                 with tempfile.TemporaryDirectory() as update_dir:
                     try:
@@ -234,7 +232,7 @@ class SafelistUpdateServer(ServiceUpdater):
                         file = url_download(source=source, previous_update=old_update_time, logger=self.log,
                                             output_dir=update_dir)
 
-                        file = extract_safelist(file, orig_source_pattern, self.log)
+                        file = extract_safelist(file, source['pattern'], self.log)
                         # Add to collection of sources for caching purposes
                         self.log.info(f"Found new {self.updater_type} rule files to process for {source_name}!")
                         previous_hashes[source_name] = {file: get_sha256_for_file(file)}


### PR DESCRIPTION
Addresses: https://github.com/CybercentreCanada/assemblyline-service-safelist/issues/15

The limitation seems to comes from the ISO9660 format (at least, that's what I suspect). So I took a page from Extract and will use 7z as the primary extraction tool to handle both ISOs and ZIPs.