### PR TITLE
Use batched NSRL insertion

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 assemblyline
 assemblyline-v4-service
 pycdlib
-pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 assemblyline
 assemblyline-v4-service
 pycdlib
+pandas

--- a/safelist/update_server.py
+++ b/safelist/update_server.py
@@ -7,12 +7,12 @@ import sys
 import tempfile
 import time
 
+import pandas as pd
 import pycdlib
 import requests
 from assemblyline.common.digests import get_sha256_for_file
 from assemblyline.common.str_utils import safe_str
 from assemblyline.odm.models.service import Service, UpdateSource
-from assemblyline_v4_service.updater.client import UpdaterClient
 from assemblyline_v4_service.updater.helper import BLOCK_SIZE, SkipSource, add_cacert, git_clone_repo, urlparse
 from assemblyline_v4_service.updater.updater import (
     SOURCE_UPDATE_ATTEMPT_DELAY_BASE,
@@ -194,8 +194,11 @@ class SafelistUpdateServer(ServiceUpdater):
         super().__init__(*args, **kwargs)
 
     def import_update(self, file_path, source_name: str, *args, **kwargs):
-        with open(file_path) as fh:
-            reader = csv.reader(fh, delimiter=",", quotechar='"')
+        HASH_LEN = os.getenv('BATCH_SAFELIST_HASH', 1000)
+        self.log.info(f"Walk by hash of {HASH_LEN} into {file_path}")
+        success = 0
+        for chunks in pd.read_csv(file_path, chunksize=HASH_LEN, low_memory=False, delimiter=",", quotechar='"'):
+            self.log.info(f"Total hash uploaded at started of loop by chunk : {success} ")
             hash_list = []
 
             def add_hash_set() -> int:
@@ -206,7 +209,7 @@ class SafelistUpdateServer(ServiceUpdater):
                     self.log.error(f"Failed to insert hash into safelist: {str(e)}")
                 return 0
 
-            for line in reader:
+            for index, line in chunks.iterrows():
                 try:
                     if len(line) == 5:
                         # No commas in filename
@@ -244,6 +247,14 @@ class SafelistUpdateServer(ServiceUpdater):
                     continue
 
                 hash_list.append(data)
+
+                if len(hash_list) % HASH_LEN == 0:
+                    # Add [HASH_LEN] item batch, record success, then start anew
+                    success += add_hash_set()
+                    hash_list = []
+
+            # Add any remaining items to safelist (if any)
+            success += add_hash_set()
 
         os.unlink(file_path)
         self.log.info(f"Import finished. {add_hash_set()} hashes have been processed.")

--- a/safelist/update_server.py
+++ b/safelist/update_server.py
@@ -21,6 +21,8 @@ from assemblyline_v4_service.updater.updater import (
     classification,
 )
 
+HASH_LEN = 1000
+
 csv.field_size_limit(sys.maxsize)
 
 
@@ -194,6 +196,7 @@ class SafelistUpdateServer(ServiceUpdater):
         super().__init__(*args, **kwargs)
 
     def import_update(self, file_path, source_name: str, *args, **kwargs):
+        success = 0
         with open(file_path) as fh:
             reader = csv.reader(fh, delimiter=",", quotechar='"')
             hash_list = []
@@ -245,8 +248,16 @@ class SafelistUpdateServer(ServiceUpdater):
 
                 hash_list.append(data)
 
+                if len(hash_list) % HASH_LEN == 0:
+                    # Add 1000 item batch, record success, then start anew
+                    success += add_hash_set()
+                    hash_list = []
+
+            # Add any remaining items to safelist (if any)
+            success += add_hash_set()
+
         os.unlink(file_path)
-        self.log.info(f"Import finished. {add_hash_set()} hashes have been processed.")
+        self.log.info(f"Import finished. {success} hashes have been processed.")
 
     def do_local_update(self) -> None:
         # No need to perform local updates, all service usage will be with service-server or directly with the datastore

--- a/safelist/update_server.py
+++ b/safelist/update_server.py
@@ -12,7 +12,7 @@ import requests
 from assemblyline.common.digests import get_sha256_for_file
 from assemblyline.common.str_utils import safe_str
 from assemblyline.odm.models.service import Service, UpdateSource
-from assemblyline_v4_service.updater.client import UpdaterClient
+from assemblyline_v4_service.updater.client import UpdaterClient, SIGNATURE_UPDATE_BATCH
 from assemblyline_v4_service.updater.helper import BLOCK_SIZE, SkipSource, add_cacert, git_clone_repo, urlparse
 from assemblyline_v4_service.updater.updater import (
     SOURCE_UPDATE_ATTEMPT_DELAY_BASE,
@@ -20,8 +20,6 @@ from assemblyline_v4_service.updater.updater import (
     ServiceUpdater,
     classification,
 )
-
-HASH_LEN = 1000
 
 csv.field_size_limit(sys.maxsize)
 
@@ -248,7 +246,7 @@ class SafelistUpdateServer(ServiceUpdater):
 
                 hash_list.append(data)
 
-                if len(hash_list) % HASH_LEN == 0:
+                if len(hash_list) % SIGNATURE_UPDATE_BATCH == 0:
                     # Add 1000 item batch, record success, then start anew
                     success += add_hash_set()
                     hash_list = []


### PR DESCRIPTION
With the current NSRL insertion implementation of the update server, the server needs to load the entire NSRL database in memory. This can make the service crash if not enough RAM is available.

Using pandas, it is possible to load `n` lines of a CSV file using a generator, which will save a lot of memory. 